### PR TITLE
Add support for rocket_contrib's uuids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "okapi",
     "rocket-okapi",
     "rocket-okapi-codegen",
-    "examples/json-web-api"
+    "examples/json-web-api",
+    "examples/uuid"
 ]

--- a/examples/uuid/.gitignore
+++ b/examples/uuid/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+/.idea

--- a/examples/uuid/Cargo.toml
+++ b/examples/uuid/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uuid"
+version = "0.1.0"
+authors = ["Graham Esau <gesau@hotmail.co.uk>"]
+edition = "2018"
+
+[dependencies]
+rocket = { git = "https://github.com/SergioBenitez/Rocket.git", branch = "master", default-features = false }
+schemars = { version = "0.8", features = ["preserve_order", "uuid"] }
+okapi = { version = "0.5.0-alpha-1", path = "../../okapi" }
+rocket_okapi = { version = "0.6.0-alpha-1", path = "../../rocket-okapi", features = ["uuid"] }
+serde = "1.0"
+uuid = { version = "0.8.2", features = ["v4"] }
+
+[dependencies.rocket_contrib]
+git = "https://github.com/SergioBenitez/Rocket.git"
+branch = "master"
+default-features = false
+features = ["json", "uuid"]

--- a/examples/uuid/README.md
+++ b/examples/uuid/README.md
@@ -1,0 +1,5 @@
+# UUID example
+
+Similar to the `json-web-api` example, this project creates a small API demonstrating the use of UUIDs in path parameters and returned JSON values.
+
+The openapi document will be hosted at `/openapi.json`, and the Swagger UI will be at `/swagger-ui`.

--- a/examples/uuid/src/main.rs
+++ b/examples/uuid/src/main.rs
@@ -1,0 +1,70 @@
+#[macro_use]
+extern crate rocket;
+#[macro_use]
+extern crate rocket_okapi;
+
+use rocket_contrib::{json::Json, uuid::Uuid};
+use rocket_okapi::swagger_ui::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct User {
+    user_id: uuid::Uuid,
+}
+
+/// # Get all users
+///
+/// Returns all users in the system.
+#[openapi]
+#[get("/user")]
+fn get_all_users() -> Json<Vec<User>> {
+    Json(vec![User {
+        user_id: uuid::Uuid::new_v4(),
+    }])
+}
+
+/// # Get user
+///
+/// Returns a single user by ID.
+#[openapi]
+#[get("/user/<id>")]
+fn get_user(id: Uuid) -> Option<Json<User>> {
+    Some(Json(User { user_id: *id }))
+}
+
+/// # Get user by name
+///
+/// Returns a single user by username.
+#[openapi]
+#[get("/user_example?<id>")]
+fn get_user_by_name(id: Uuid) -> Option<Json<User>> {
+    Some(Json(User { user_id: *id }))
+}
+
+/// # Create user
+#[openapi]
+#[post("/user", data = "<user>")]
+fn create_user(user: Json<User>) -> Json<User> {
+    user
+}
+
+#[rocket::main]
+async fn main() {
+    let result = rocket::build()
+        .mount(
+            "/",
+            routes_with_openapi![get_all_users, get_user, get_user_by_name, create_user,],
+        )
+        .mount(
+            "/swagger-ui/",
+            make_swagger_ui(&SwaggerUIConfig {
+                url: "../openapi.json".to_owned(),
+                ..Default::default()
+            }),
+        )
+        .launch()
+        .await;
+    assert!(result.is_ok());
+}

--- a/rocket-okapi/Cargo.toml
+++ b/rocket-okapi/Cargo.toml
@@ -15,9 +15,10 @@ okapi = { version = "0.5.0-alpha-1", path = "../okapi" }
 rocket_okapi_codegen = { version = "=0.6.0-alpha-1", path = "../rocket-okapi-codegen" }
 serde = "1.0"
 serde_json = "1.0"
+uuid = { version = "0.8.2", optional = true }
 
 [dependencies.rocket_contrib]
 git = "https://github.com/SergioBenitez/Rocket.git"
 branch = "master"
 default-features = false
-features = ["json"]
+features = ["json", "uuid"]

--- a/rocket-okapi/src/request/from_form_param_impls.rs
+++ b/rocket-okapi/src/request/from_form_param_impls.rs
@@ -74,6 +74,30 @@ impl<'r> OpenApiFromFormField<'r> for &'r str {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl OpenApiFromFormField<'_> for rocket_contrib::uuid::Uuid {
+    fn form_parameter(gen: &mut OpenApiGenerator, name: String, required: bool) -> Result {
+        let schema = gen.json_schema::<uuid::Uuid>();
+        Ok(Parameter {
+            name,
+            location: "query".to_owned(),
+            description: None,
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        })
+    }
+}
+
 // OpenAPI specification does not support optional path params, so we leave `required` as true,
 // even for Options and Results.
 impl<'r, T: OpenApiFromFormField<'r>> OpenApiFromFormField<'r> for FormResult<'r, T> {

--- a/rocket-okapi/src/request/from_param_impls.rs
+++ b/rocket-okapi/src/request/from_param_impls.rs
@@ -72,6 +72,30 @@ impl<'r> OpenApiFromParam<'r> for &'r str {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl<'r> OpenApiFromParam<'_> for rocket_contrib::uuid::Uuid {
+    fn path_parameter(gen: &mut OpenApiGenerator, name: String) -> Result {
+        let schema = gen.json_schema::<uuid::Uuid>();
+        Ok(Parameter {
+            name,
+            location: "path".to_owned(),
+            description: None,
+            required: true,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: None,
+                examples: None,
+            },
+            extensions: Default::default(),
+        })
+    }
+}
+
 // OpenAPI specification does not support optional path params, so we leave `required` as true,
 // even for Options and Results.
 impl<'r, T: OpenApiFromParam<'r>> OpenApiFromParam<'r> for StdResult<T, T::Error> {


### PR DESCRIPTION
This should fix https://github.com/GREsau/okapi/issues/38. I'm creating the PR here as we're using your branch in our application.

It should be noted that `FromForm` still does not work with rocket_contrib uuids, because they do not implement the `JsonSchema` trait. This should probably be fixed in schemars by adding support for rocket_contrib.